### PR TITLE
Add support for --nogrouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ Options:
   --functionCase  Case of the function names
          [string] [choices: "unchanged", "lowercase", "uppercase", "capitalize"]
                                                           [default: "unchanged"]
+  --noGrouping    Add a newline between statements in transaction regroupement
+                                                      [boolean] [default: false]
   --keywordCase   Case of the reserved keywords
          [string] [choices: "unchanged", "lowercase", "uppercase", "capitalize"]
                                                           [default: "uppercase"]
   --formatType    Use another formatting type for some statements      [boolean]
-  --placeholder   Regex to find code that must not be changed           [string]                                        
+  --placeholder   Regex to find code that must not be changed           [string]
   --perlBinPath   The path to the perl executable     [string] [default: "perl"]
 ```
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -47,6 +47,11 @@ By default, output is written to stdout. (use --write option to edit files in-pl
             choices: ["unchanged", "lowercase", "uppercase", "capitalize"],
             describe: "Case of the function names"
         },
+        noGrouping: {
+            type: "boolean",
+            default: false,
+            describe: "Add a newline between statements in transaction regroupement"
+        },
         keywordCase: {
             type: "string",
             default: "uppercase",

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,7 +15,7 @@ function formatFiles(filesOrGlobs, editInPlace, options = {}, log = console.log)
     for (let path of paths) {
         let startTime = process.hrtime();
         let command = `${buildCommand(options)} ${path}`;
-        // Run pgFormatter    
+        // Run pgFormatter
         let output = child_process_1.execSync(command, {
             encoding: "utf8"
         });
@@ -75,6 +75,9 @@ function buildCommandArguments(options) {
     }
     if (options.functionCase != null) {
         commandArgs += ` --function-case ${options.functionCase}`;
+    }
+    if (options.noGrouping) {
+        commandArgs += " --nogrouping";
     }
     if (options.keywordCase != null) {
         commandArgs += ` --keyword-case ${options.keywordCase}`;

--- a/dist/options.d.ts
+++ b/dist/options.d.ts
@@ -7,6 +7,7 @@ export interface IOptions {
     commaEnd?: boolean;
     noComment?: boolean;
     functionCase?: CaseOptionEnum;
+    noGrouping?: boolean;
     keywordCase?: CaseOptionEnum;
     formatType?: boolean;
     placeholder?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,11 @@ By default, output is written to stdout. (use --write option to edit files in-pl
         choices: ["unchanged", "lowercase", "uppercase", "capitalize"],
         describe: "Case of the function names"
       },
+      noGrouping: {
+        type: "boolean",
+        default: false,
+        describe: "Add a newline between statements in transaction regroupement"
+      },
       keywordCase: {
         type: "string",
         default: "uppercase",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export function formatFiles(
   for (let path of paths) {
     let startTime = process.hrtime();
     let command = `${buildCommand(options)} ${path}`;
-    // Run pgFormatter    
+    // Run pgFormatter
     let output = execSync(command, {
       encoding: "utf8"
     });
@@ -91,6 +91,10 @@ export function buildCommandArguments(options: IOptions) {
 
   if (options.functionCase != null) {
     commandArgs += ` --function-case ${options.functionCase}`;
+  }
+
+  if (options.noGrouping) {
+    commandArgs += " --nogrouping";
   }
 
   if (options.keywordCase != null) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,7 @@ export interface IOptions {
   commaEnd?: boolean;
   noComment?: boolean;
   functionCase?: CaseOptionEnum;
+  noGrouping?: boolean;
   keywordCase?: CaseOptionEnum;
   formatType?: boolean;
   placeholder?: string;

--- a/test/options.ts
+++ b/test/options.ts
@@ -4,7 +4,8 @@ import { expect } from "chai";
 
 describe("options", function() {
   it("write", function() {
-    expect(buildCommandArguments({ write: true })).to.not.contain("write");    
+    // write argument is not passed pgFormatter but is used internally
+    expect(buildCommandArguments({ write: true })).not.to.contain("write");    
   });
   
   it("commaStart", function() {

--- a/test/options.ts
+++ b/test/options.ts
@@ -30,6 +30,10 @@ describe("options", function() {
     expect(buildCommandArguments({ functionCase: CaseOptionEnum.lowercase })).to.contain("--function-case 1");
   });
 
+  it("noGrouping", function() {
+    expect(buildCommandArguments({ noGrouping: true })).to.contain("--nogrouping");
+  });
+
   it("maxLength", function() {
     expect(buildCommandArguments({ maxLength: 120 })).to.contain("--maxlength 120");
   });


### PR DESCRIPTION
Adds support for --nogrouping option under the `noGrouping` option name.

```
-g | --nogrouping     : add a newline between statements in transaction
                        regroupement. Default is to group statements.
```

Fixes #14