### PR TITLE
Add `configFile` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Options:
   --wrapLimit      Wrap queries at a certain length                     [number]
   --placeholder    Regex to find code that must not be changed          [string]
   --extraFunction  Path to file containing a list of function names     [string]
+  --configFile     Specify a pg_format config file                      [string]
   --perlBinPath    The path to the perl executable    [string] [default: "perl"]
 ```
 
@@ -125,6 +126,7 @@ let formatted = psqlformat.formatSql("select id from people", {
   formatType
   placeholder
   extraFunction
+  configFile
   perlBinPath
   */
 });

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -78,6 +78,10 @@ By default, output is written to stdout. (use --write option to edit files in-pl
             type: "string",
             describe: "Path to file containing a list of function names"
         },
+        configFile: {
+            type: "string",
+            describe: "Specify a pg_format config file",
+        },
         perlBinPath: {
             type: "string",
             default: "perl",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildCommandArguments = exports.buildCommand = exports.CaseOptionEnum = exports.formatSql = exports.formatFiles = void 0;
 const path = require("path");
 const fs = require("fs");
 const globby = require("globby");
@@ -46,7 +47,7 @@ function formatSql(sqlText, options = {}) {
 }
 exports.formatSql = formatSql;
 var options_1 = require("./options");
-exports.CaseOptionEnum = options_1.CaseOptionEnum;
+Object.defineProperty(exports, "CaseOptionEnum", { enumerable: true, get: function () { return options_1.CaseOptionEnum; } });
 function buildCommand(options) {
     let pgFormatterPath = path.resolve(__dirname, "../vendor/pgFormatter/pg_format");
     let commandArgs = buildCommandArguments(options);
@@ -96,6 +97,9 @@ function buildCommandArguments(options) {
     }
     if (options.extraFunction != null) {
         commandArgs += ` --extra-function '${options.extraFunction}'`;
+    }
+    if (options.configFile != null) {
+        commandArgs += ` --config '${options.configFile}'`;
     }
     return commandArgs;
 }

--- a/dist/options.d.ts
+++ b/dist/options.d.ts
@@ -14,6 +14,7 @@ export interface IOptions {
     wrapLimit?: number;
     placeholder?: string;
     extraFunction?: string;
+    configFile?: string;
     perlBinPath?: string;
 }
 export declare enum CaseOptionEnum {

--- a/dist/options.js
+++ b/dist/options.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.CaseOptionEnum = void 0;
 var CaseOptionEnum;
 (function (CaseOptionEnum) {
     CaseOptionEnum[CaseOptionEnum["unchanged"] = 0] = "unchanged";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,10 @@ By default, output is written to stdout. (use --write option to edit files in-pl
         type: "string",
         describe: "Path to file containing a list of function names"
       },
+      configFile: {
+        type: "string",
+        describe: "Specify a pg_format config file",
+      },
       perlBinPath: {
         type: "string",
         default: "perl",

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,11 @@ export function buildCommandArguments(options: IOptions) {
   }
 
   if (options.extraFunction != null) {
-    commandArgs += ` --extra-function '${options.extraFunction}'`
+    commandArgs += ` --extra-function '${options.extraFunction}'`;
+  }
+
+  if (options.configFile != null) {
+    commandArgs += ` --config '${options.configFile}'`;
   }
 
   return commandArgs;

--- a/src/options.ts
+++ b/src/options.ts
@@ -14,6 +14,7 @@ export interface IOptions {
   wrapLimit?: number;
   placeholder?: string;
   extraFunction?: string;
+  configFile?: string;
 
   perlBinPath?: string;
 }

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -86,4 +86,20 @@ PERFORM
 
 `);
   });
+
+  it("formats a file using config file", function() {
+    let output = checkOutput(() => {
+      cli.exec(["--configFile=test/support/pg_format.conf", queryFilePath]);
+    });
+
+    expect(output.errors).to.be.empty;
+    expect(output.logs[0]).to.equal(`\
+/* This is a comment */
+SELECT
+    id,
+    first_name
+FROM
+    people
+`);
+  });
 });

--- a/test/formatting.ts
+++ b/test/formatting.ts
@@ -2,7 +2,7 @@ import { formatSql, formatFiles } from "../src/index";
 import { expect } from "chai";
 
 describe("formatting", function() {
-  it("returns formatted SQL given SQL text", function() {
+  it("returns formatted SQL given SQL text", function () {
     expect(
       formatSql(`\
 PERFORM my_nifty_function(id, name);
@@ -27,6 +27,24 @@ PERFORM my_nifty_function(id, name);
     ).to.equal(`\
 PERFORM
     my_nifty_function(id, name);
+
+`);
+  });
+
+  it("returns respects the configFile option", function() {
+    expect(
+      formatSql(
+        `\
+-- comment
+PERFORM my_nifty_function(id, name);
+\
+`,
+        { configFile: "test/support/pg_format.conf" }
+      )
+    ).to.equal(`\
+-- comment
+PERFORM
+    my_nifty_function (id, name);
 
 `);
   });

--- a/test/options.ts
+++ b/test/options.ts
@@ -62,7 +62,11 @@ describe("options", function() {
     expect(buildCommandArguments({ extraFunction: "/test123/test456" })).to.contain(
       "--extra-function '/test123/test456'"
     )
-  })
+  });
+
+  it("configFile", function() {
+    expect(buildCommandArguments({ configFile: "/test123/conf" })).to.contain("--config '/test123/conf'");
+  });
 
   it("perlBinPath", function() {
     expect(buildCommand({ perlBinPath: '/usr/bin/custom' })).contain("/usr/bin/custom");

--- a/test/support/pg_format.conf
+++ b/test/support/pg_format.conf
@@ -1,0 +1,76 @@
+####
+# Copy this file as ~/.pg_format and adjust the default settings
+# if you want to control the default behavior of pgFormatter.
+####
+
+# Obscure all literals in queries, use to hide confidential data before formatting.
+anonymize=0
+
+# In a parameters list, end or start with the comma. Default: end
+comma=end
+
+# In insert statement, add a newline after each comma.
+comma-break=0
+
+# Output format: text or html. Default: text.
+format=text
+
+# Add a newline between statements in transaction regroupement. Default is to group statements.
+nogrouping=0
+
+# Change the case of the reserved keyword. Default is uppercase: 2.
+# Values: 0=>unchanged, 1=>lowercase, 2=>uppercase, 3=>capitalize.
+keyword-case=2
+
+# Change the case of the data type name. Default is lowercase: 1.
+# Values: 0=>unchanged, 1=>lowercase, 2=>uppercase, 3=>capitalize.
+type-case=1
+
+# Change the case of the reserved keyword. Default is unchanged: 0.
+# Values: 0=>unchanged, 1=>lowercase, 2=>uppercase, 3=>capitalize.
+function-case=0
+
+# Do not add an extra empty line at end of the output.
+no-extra-line=0
+
+# Maximum length of a query, it will be cutted above the given size. Default: no truncate.
+maxlength=0
+
+# Remove any comment from SQL code.
+nocomment=0
+
+# Statement numbering as a comment before each query.
+numbering=0
+
+# Define the filename for the output. Default: stdout.
+output=
+
+# Set regex to find code that must not be changed.
+placeholder=
+
+# Add RedShift keyworks to the list of SQL keyworks.
+redshift=0
+
+# Dynamic code separator, default to single quote.
+separator=
+
+# Change space indent, default 4 spaces.
+spaces=4
+
+# Try another formatting type for some statements.
+format-type=0
+
+# Use tabs instead of space characters, when used spaces is set to 1 whatever is its value
+tabs=0
+
+# Wrap queries at a certain length.
+wrap-limit=0
+
+# Number of column after which lists must be wrapped.
+wrap-after=0
+
+# with --wrap-limit, apply reformatting to comments.
+wrap-comment=0
+
+# Add a list of function to be formatted as PG internal functions
+#extra-function=/opt/pgFormatter/functions.lst


### PR DESCRIPTION
This is passed through to `pg_format`.

It should be noted that `pg_format` looks in `~/.pg_format` if it exists
unless you tell it not to do so.  I couldn't find anywhere this was done
in this lib, so adding that file *should* work for i.e. the vscode
extension.  I haven't tested this, but it would be a great alternative
to allow a single place for configuraation.