### PR TITLE
Pass multiple filenames and `--inplace` to `pgFormatter`

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -80,7 +80,7 @@ By default, output is written to stdout. (use --write option to edit files in-pl
         },
         noSpaceFunction: {
             type: "boolean",
-            describe: "Remove the space character between a function call and the open parenthesis that follow",
+            describe: "Remove the space character between a function call and the open parenthesis that follows",
         },
         configFile: {
             type: "string",
@@ -94,6 +94,11 @@ By default, output is written to stdout. (use --write option to edit files in-pl
         pgFormatterPath: {
             type: "string",
             describe: "Path to a custom pg_format version",
+        },
+        chunkSize: {
+            type: "number",
+            describe: "How many files to pass to pgFormatter at once",
+            default: "25",
         },
     })
         .demandCommand(1, "").argv;

--- a/dist/options.d.ts
+++ b/dist/options.d.ts
@@ -16,6 +16,7 @@ export interface IOptions {
     extraFunction?: string;
     configFile?: string;
     noSpaceFunction?: boolean;
+    chunkSize?: number;
     perlBinPath?: string;
     pgFormatterPath?: string;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,11 @@ By default, output is written to stdout. (use --write option to edit files in-pl
         type: "string",
         describe: "Path to a custom pg_format version",
       },
+      chunkSize: {
+        type: "number",
+        describe: "How many files to pass to pgFormatter at once",
+        default: "25",
+      },
     })
     .demandCommand(1, "").argv;
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,6 +16,7 @@ export interface IOptions {
   extraFunction?: string;
   configFile?: string;
   noSpaceFunction?: boolean;
+  chunkSize?: number;
 
   perlBinPath?: string;
   pgFormatterPath?: string;


### PR DESCRIPTION
`pgFormatter` supports passing multiple filenames, and the `--inplace` argument to update these directly.  With these two changes, we can process many files in each `pgFormatter` execution, which is somewhat faster:

When using my local project with 480 SQL files (approx 1.1MB total)
- The current "one at a time" takes 38 seconds
- Doing in chunks of 10 takes 19.2 seconds
- Doing in chunks of 25 (default in this PR) takes 17.8 seconds
- Doing in chunks of 100 takes 17.3 seconds
