### PR TITLE
`upgrade-pgFormatter.js` does not need Github token, and can use `curl`

### DIFF
--- a/scripts/upgrade-pgFormatter.js
+++ b/scripts/upgrade-pgFormatter.js
@@ -6,7 +6,7 @@ cd(__dirname);
 
 const latestRelease = JSON.parse(
   $(
-    `curl -H "Authorization: token $GITHUB_API_TOKEN" -H "Content-Type: application/json" \
+    `curl -H "Content-Type: application/json" \
  https://api.github.com/repos/darold/pgFormatter/releases/latest`
   )
 );

--- a/scripts/upgrade-pgFormatter.js
+++ b/scripts/upgrade-pgFormatter.js
@@ -29,7 +29,7 @@ const releaseDownloadFileName = "release.zip";
 const releaseDownloadFolder = "release/";
 
 echo("Downloading latest release...");
-exec(`wget -O ${releaseDownloadFileName} ${latestRelease.zipball_url}`);
+exec(`curl --location --output ${releaseDownloadFileName} ${latestRelease.zipball_url}`);
 exec(`unzip ${releaseDownloadFileName} -d ${releaseDownloadFolder}`);
 
 const targetFilePath = "../vendor/pgFormatter/";


### PR DESCRIPTION
When I tried to run the `scripts/upgrade-pgFormatter.js` file, I had two errors:
- I did not have a `GITHUB_API_TOKEN` env var set
- My MacOS shell does not have `wget` installed

The Github token is not needed to pull `pgFormatter` releases - they are publicly available.  So that can just be removed.

We can also use `curl` instead of `wget`.  I think `curl` is generally more widely available, but perhaps that's just a quirk of my system?